### PR TITLE
chore(mocha): use spec reporter instead of nyan

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---reporter nyan
+--reporter spec
 --ui bdd


### PR DESCRIPTION
Travis output doesn't play nice with the nyan cat, which makes me very
sad.
