### PR TITLE
fix(*/create): metadata must be a String

### DIFF
--- a/lib/alarms/create.js
+++ b/lib/alarms/create.js
@@ -27,7 +27,7 @@ function createOne(props, cb) {
     check_id: props.check.id,
     notification_plan_id: props.notificationPlanId,
     metadata: {
-      pandamonium: Date.now()
+      pandamonium: ''+Date.now()
     }
   };
 

--- a/lib/checks/create.js
+++ b/lib/checks/create.js
@@ -71,7 +71,7 @@ function createOne(props, cb) {
     type: checkType.type,
     label: label,
     metadata: {
-      pandamonium: Date.now()
+      pandamonium: ''+Date.now()
     }
   };
 

--- a/lib/entities/create.js
+++ b/lib/entities/create.js
@@ -19,7 +19,7 @@ function create(chance, cb) {
     label: label,
     ip_addresses: ips,
     metadata: {
-      pandamonium: Date.now()
+      pandamonium: ''+Date.now()
     }
   };
 

--- a/lib/notification-plans/create.js
+++ b/lib/notification-plans/create.js
@@ -22,7 +22,7 @@ function createOne(props, cb) {
     warning_state: selectedPlans,
     ok_state: selectedPlans,
     metadata: {
-      pandamonium: Date.now()
+      pandamonium: ''+Date.now()
     }
   };
 

--- a/lib/notifications/create.js
+++ b/lib/notifications/create.js
@@ -42,7 +42,7 @@ function create(chance, cb) {
     type: type,
     details: getDetailsByType(chance, type),
     metadata: {
-      pandamonium: Date.now()
+      pandamonium: ''+Date.now()
     }
   };
 

--- a/test/entities.js
+++ b/test/entities.js
@@ -100,7 +100,7 @@ describe('Entity', function () {
             internet0_v4: "43.15.224.171"
           },
           metadata: {
-            pandamonium: 1419544462490
+            pandamonium: "1419544462490"
           },
           id: "en123456"
         });

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -100,7 +100,7 @@ describe('Notification', function () {
             phone_number: "+1395843652"
           },
           metadata: {
-            pandamonium: 1419544462490
+            pandamonium: "1419544462490"
           },
           id: "nt123456"
         });


### PR DESCRIPTION
Metadata values submitted to Cloud Monitoring must be strings. Mimic
doesn't check for this, so it got past our testing for a while.